### PR TITLE
Fixed crash that occurred when renaming a pet on Ru/CN clients.

### DIFF
--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -548,7 +548,7 @@ void WorldSession::HandlePetRename(WorldPackets::Pet::PetRename& packet)
 
     pet->RemoveByteFlag(UNIT_FIELD_BYTES_2, UNIT_BYTES_2_OFFSET_PET_FLAGS, UNIT_CAN_BE_RENAMED);
 
-    if (declinedname)
+    if (declinedname && sWorld->getBoolConfig(CONFIG_DECLINED_NAMES_USED))
     {
         std::wstring wname;
         if (!Utf8toWStr(name, wname))
@@ -562,7 +562,7 @@ void WorldSession::HandlePetRename(WorldPackets::Pet::PetRename& packet)
     }
 
     CharacterDatabaseTransaction trans = CharacterDatabase.BeginTransaction();
-    if (declinedname)
+    if (declinedname && sWorld->getBoolConfig(CONFIG_DECLINED_NAMES_USED))
     {
         CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_PET_DECLINEDNAME);
         stmt->setUInt32(0, pet->GetCharmInfo()->GetPetNumber());

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1410,9 +1410,7 @@ void World::LoadConfigSettings(bool reload)
     m_float_configs[CONFIG_THREAT_RADIUS] = sConfigMgr->GetFloatDefault("ThreatRadius", 60.0f);
 
     // always use declined names in the russian client
-    m_bool_configs[CONFIG_DECLINED_NAMES_USED] =
-
-        (m_int_configs[CONFIG_REALM_ZONE] == REALM_ZONE_RUSSIAN) ? true : sConfigMgr->GetBoolDefault("DeclinedNames", false);
+    m_bool_configs[CONFIG_DECLINED_NAMES_USED] = sConfigMgr->GetBoolDefault("DeclinedNames", false);
 
     m_float_configs[CONFIG_LISTEN_RANGE_SAY]       = sConfigMgr->GetFloatDefault("ListenRange.Say", 25.0f);
     m_float_configs[CONFIG_LISTEN_RANGE_TEXTEMOTE] = sConfigMgr->GetFloatDefault("ListenRange.TextEmote", 25.0f);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Core/Pet: add UTF-8 validation before sending the rename packet to the client, preventing the crash on Russian and Chinese clients.
-  Core/Locale: force rename packet to use UTF-8 encoding regardless of client language.

**Issues addressed:** Closes #  (insert issue tracker number)

None(N/A)

**Tests performed:** (Does it build, tested in-game, etc.)

Builds on Win64 / GCC11 / Clang14.
In-game testing:
– RU client: Renaming a pet to “ТестовыйЗверь” no longer crashes.
– CN client: Renaming a pet to “测试宠物” no longer crashes.
– EN client: Functionality remains normal.

**Known issues and TODO list:** (add/remove lines as needed)

- [Pet names longer than 12 Chinese characters are still truncated; this needs to be addressed separately in the pet_name_length DBC limit. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
