### PR TITLE
fix dh soul cleave pain cost

### DIFF
--- a/src/server/scripts/Spells/spell_dh.cpp
+++ b/src/server/scripts/Spells/spell_dh.cpp
@@ -920,7 +920,6 @@ public:
             SetHitDamage(dmg);
 
             caster->SetPower(POWER_PAIN, caster->GetPower(POWER_PAIN) - m_ExtraSpellCost);
-            caster->ToPlayer()->SetPower(POWER_PAIN, caster->GetPower(POWER_PAIN) - m_ExtraSpellCost);
             if (caster->HasAura(SPELL_DH_GLUTTONY_BUFF))
                 caster->RemoveAurasDueToSpell(SPELL_DH_GLUTTONY_BUFF);
         }


### PR DESCRIPTION
 Fixes Demon Hunter Soul Cleave extra Pain cost being subtracted twice.

  The damage script already removes m_ExtraSpellCost once. The second SetPower call used the already-reduced Pain value and removed the same extra cost again.