### PR TITLE
fix revive battle pet spell learning

### DIFF
--- a/sql/updates/world/2026_05_20_00_world.sql
+++ b/sql/updates/world/2026_05_20_00_world.sql
@@ -1,0 +1,2 @@
+-- When you learn battle pet training you now learn revive battle pets
+INSERT INTO `world`.`spell_learn_spell` (`entry`, `SpellID`, `Active`) VALUES (119467, 125439, 1);


### PR DESCRIPTION
fix missing linked learn spell. Now when you learn battle pet training you now gain the ability to revive them as well.

" Revive Battle Pets is an ability that heals a player's Battle Pets to full health, and resurrects any pets that are dead. It is gained through learning [Battle Pet Training]. "

(2012-08-28): Added.

