### PR TITLE
add missing trinity_string entries for shutdown commands

### DIFF
--- a/sql/updates/world/2026_05_25_00_world.sql
+++ b/sql/updates/world/2026_05_25_00_world.sql
@@ -1,0 +1,7 @@
+-- Add missing trinity_string entries for server shutdown console commands
+-- LANG_SHUTDOWN_DELAYED (11017) and LANG_SHUTDOWN_CANCELLED (11018) are referenced
+-- in cs_server.cpp but were never inserted into the base world database.
+DELETE FROM `trinity_string` WHERE `entry` IN (11017, 11018);
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
+(11017, 'Server shutdown delayed to %d seconds as other users are still connected. Specify ''force'' to override.'),
+(11018, 'Server shutdown scheduled for T+%d seconds was successfully cancelled.');


### PR DESCRIPTION
**Changes proposed:**

DELETE FROM trinity_string WHERE entry IN (11017, 11018);
INSERT INTO trinity_string (entry, content_default) VALUES
(11017, 'Server shutdown delayed to %d seconds as other users are still connected. Specify ''force'' to override.'),
(11018, 'Server shutdown scheduled for T+%d seconds was successfully cancelled.');

**Issues addressed:** Closes #  (insert issue tracker number)
LANG_SHUTDOWN_DELAYED (entry 11017) and LANG_SHUTDOWN_CANCELLED (entry 11018) missing

